### PR TITLE
Fix masks to make press/release/up/down consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Debounce16 Library
 
-A robust 16-bit pattern-based button debouncing library for ESP32 microcontrollers using the Arduino framework.
+A robust 16-bit pattern-based button debouncing library for ESP32 microcontrollers using the Arduino or ESP-IDF frameworks.
 
 ## Features
 
@@ -119,6 +119,71 @@ void loop() {
 }
 ```
 
+### Using Hardware Timer Interrupt with latest Arduino
+
+```cpp
+#include <Debounce16.h>
+
+const uint8_t PIN_BUTTON = 17;
+Debounce16 button(PIN_BUTTON, HIGH);
+
+hw_timer_t *timer = NULL;
+
+void IRAM_ATTR onTimer() {
+    button.update();  // Update at precise 1ms intervals
+}
+
+void setup() {
+    // Configure timer for 1 MHz and callback every 1000 ticks
+    timer = timerBegin(1000000); // 1 MHz
+    timerAttachInterrupt(timer, &onTimer);
+    timerAlarm(buttonTimer, 1000, true, 0);  // 1ms, autoreload, forever
+}
+
+void loop() {
+    if (button.isPressed()) {
+        // Handle button press
+    }
+}
+```
+
+### Using Hardware Timer Interrupt with ESP-IDF
+
+```cpp
+#include <Debounce16.h>
+
+#include "esp_timer.h"
+
+const uint8_t PIN_BUTTON = 17;
+Debounce16 button(PIN_BUTTON, DB_HIGH);
+
+hw_timer_t *timer = NULL;
+
+void IRAM_ATTR onTimer(void *) {
+    button.update();  // Update at precise 1ms intervals
+}
+
+void setup() {
+  const esp_timer_create_args_t timer_args = {
+    .callback = &onButtonTimer,
+    .arg = NULL,
+    .dispatch_method = ESP_TIMER_TASK,
+    .name = "Debounce16",
+    .skip_unhandled_events = true
+  };
+  esp_timer_handle_t timer_handler;
+
+  ESP_ERROR_CHECK(esp_timer_create(&timer_args, &timer_handler));
+  ESP_ERROR_CHECK(esp_timer_start_periodic(timer_handler, 1000));
+}
+
+void loop() {
+    if (button.isPressed()) {
+        // Handle button press
+    }
+}
+```
+
 ## Advanced Features
 
 ### Double Press Detection
@@ -202,11 +267,11 @@ void loop() {
 ### Constructor
 
 ```cpp
-Debounce16(uint8_t pin, bool activeLevel = HIGH)
+Debounce16(uint8_t|gpio_num_t pin, bool activeLevel = DB_HIGH)
 ```
 
 - `pin`: GPIO pin number where button is connected
-- `activeLevel`: Logic level when button is pressed (HIGH or LOW)
+- `activeLevel`: Logic level when button is pressed (DB_HIGH or DB_LOW)
 
 ### Core Methods
 

--- a/README.md
+++ b/README.md
@@ -316,18 +316,18 @@ The library uses a 16-bit shift register to store the last 16 button state readi
 
 ### Press Detection Pattern
 
-A press is detected when the last 6 bits are all HIGH (button pressed) after being LOW:
+A press is detected when the latest 6 bits are all HIGH (button pressed) after being LOW (with some possible bounce in between, the "don't cares" being indicated as x):
 ```
-0b0000000000111111 = 0x003F
+0b00000xxxxx111111
 ```
 
 This means the button must be consistently pressed for at least 6ms before being recognized.
 
 ### Release Detection Pattern
 
-A release is detected when the first 6 bits are all HIGH (button was pressed) and the rest are LOW:
+A release is detected when the latest 6 bits are all LOW (button not pressed) and the rest are HIGH (with some possible bounce in between, the "don't cares" being indicated as x):
 ```
-0b1111110000000000 = 0xFC00
+0b11111xxxxx000000
 ```
 
 This provides excellent noise immunity while maintaining fast response times.

--- a/src/Debounce16.cpp
+++ b/src/Debounce16.cpp
@@ -167,7 +167,7 @@ bool Debounce16::isReleased()
 // ****************************************************************************
 bool Debounce16::isDown()
 {
-    return (historyButton == PATTERN_DOWN); // All 16 bits set = button down
+    return (historyButton & MASK_DOWN_UP) == PATTERN_DOWN; // Recent bits are set = button down
 }
 
 // ****************************************************************************
@@ -178,7 +178,7 @@ bool Debounce16::isDown()
 // ****************************************************************************
 bool Debounce16::isUp()
 {
-    return (historyButton == PATTERN_UP);   // All 16 bits clear = button up
+    return (historyButton & MASK_DOWN_UP) == PATTERN_UP;  // Recent bits are clear = button up
 }
 
 // Advanced Feature Configuration Implementation

--- a/src/Debounce16.cpp
+++ b/src/Debounce16.cpp
@@ -8,8 +8,20 @@
 // When         Who         Description of change
 // -----------  ----------- -----------------------
 // 30-SEP-2025  Brooks      Initial implementation
+// 28-FEB-2026  davidc      Updates to work under ESP-IDF without Arduino
 //
 // ****************************************************************************
+
+#ifndef ARDUINO
+#ifdef IDF_VER
+#include "esp_timer.h"
+
+uint32_t millis()
+{
+  return esp_timer_get_time() / 1000;
+}
+#endif
+#endif
 
 // Include Files
 // ****************************************************************************
@@ -17,7 +29,7 @@
 
 // Constructor Implementation
 // ****************************************************************************
-Debounce16::Debounce16(uint8_t pin, bool activeLevel)
+Debounce16::Debounce16(db_pin_t pin, bool activeLevel)
 {
     pinButton = pin;                        // Store GPIO pin number
     levelActive = activeLevel;              // Store active logic level
@@ -51,6 +63,7 @@ Debounce16::Debounce16(uint8_t pin, bool activeLevel)
     callbackLongPressEnd = nullptr;         // No long-press end callback
 
     // Configure GPIO pin
+#ifdef ARDUINO
     if (levelActive == HIGH)
     {
         pinMode(pin, INPUT);                // Active HIGH: use INPUT mode
@@ -59,6 +72,16 @@ Debounce16::Debounce16(uint8_t pin, bool activeLevel)
     {
         pinMode(pin, INPUT_PULLUP);         // Active LOW: use INPUT_PULLUP
     }
+#elifdef IDF_VER
+    gpio_config_t io_conf = {
+      .pin_bit_mask = (1ULL << pin),
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = (levelActive == DB_HIGH ? GPIO_PULLUP_DISABLE : GPIO_PULLUP_ENABLE),
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE
+    };
+    gpio_config(&io_conf);
+#endif
 }
 
 // Core Debouncing Methods Implementation
@@ -336,10 +359,14 @@ void Debounce16::onLongPressEnd(void (*callback)())
 // ****************************************************************************
 bool Debounce16::readButtonRaw()
 {
+#ifdef ARDUINO
     bool stateRaw = digitalRead(pinButton); // Read physical button state
+#else
+    bool stateRaw = gpio_get_level(pinButton);  // Read physical button state
+#endif
 
     // Account for active logic level
-    if (levelActive == HIGH)
+    if (levelActive == DB_HIGH)
     {
         return stateRaw;                    // Active HIGH: return as-is
     }

--- a/src/Debounce16.h
+++ b/src/Debounce16.h
@@ -17,6 +17,7 @@
 // When         Who         Description of change
 // -----------  ----------- -----------------------
 // 30-SEP-2025  Brooks      Initial implementation
+// 28-FEB-2026  davidc      Updates to work under ESP-IDF without Arduino
 //
 // ****************************************************************************
 
@@ -25,7 +26,29 @@
 
 // Include Files
 // ****************************************************************************
+#ifdef ARDUINO
+
 #include <Arduino.h>
+
+typedef uint8_t db_pin_t;
+
+#define DB_HIGH HIGH
+#define DB_LOW LOW
+
+#elifdef IDF_VER
+
+#include "driver/gpio.h"
+
+typedef gpio_num_t db_pin_t;
+
+#define DB_HIGH 1
+#define DB_LOW 0
+
+#else
+
+#error Platform not supported
+
+#endif
 
 // Class Declaration
 // ****************************************************************************
@@ -34,7 +57,7 @@ class Debounce16
 public:
     // Constructors
     // ****************************************************************************
-    Debounce16(uint8_t pin, bool activeLevel = HIGH);
+    Debounce16(db_pin_t pin, bool activeLevel = DB_HIGH);
 
     // Core Debouncing Methods (Always Available)
     // ****************************************************************************
@@ -70,7 +93,7 @@ private:
     // Core Debouncing Members
     // ****************************************************************************
     uint16_t historyButton;                 // 16-bit button state history
-    uint8_t pinButton;                      // GPIO pin number
+    db_pin_t pinButton;                  // GPIO pin number
     bool levelActive;                       // Active logic level (HIGH/LOW)
 
     // State Machine for Press Pattern Detection

--- a/src/Debounce16.h
+++ b/src/Debounce16.h
@@ -139,12 +139,14 @@ private:
 
     // Bit Pattern Constants (16-bit patterns)
     // ****************************************************************************
-    static const uint16_t MASK_PRESS = 0x003F;       // 0b0000000000111111
-    static const uint16_t PATTERN_PRESS = 0x003F;    // 0b0000000000111111
-    static const uint16_t MASK_RELEASE = 0xFC00;     // 0b1111110000000000
-    static const uint16_t PATTERN_RELEASE = 0xFC00;  // 0b1111110000000000
-    static const uint16_t PATTERN_DOWN = 0xFFFF;     // 0b1111111111111111
-    static const uint16_t PATTERN_UP = 0x0000;       // 0b0000000000000000
+    static const uint16_t MASK_PRESS =      0b1111100000111111;
+    static const uint16_t PATTERN_PRESS =   0b0000000000111111;
+    static const uint16_t MASK_RELEASE =    0b1111100000111111;
+    static const uint16_t PATTERN_RELEASE = 0b1111100000000000;
+
+    static const uint16_t MASK_DOWN_UP =    0b0000000000111111;
+    static const uint16_t PATTERN_DOWN =    0b0000000000111111;
+    static const uint16_t PATTERN_UP =      0b0000000000000000;
 
     // Helper Methods
     // ****************************************************************************


### PR DESCRIPTION
https://github.com/brooksbUWO/Debounce/pull/2 will need merging first.

Fixes part of https://github.com/brooksbUWO/Debounce/issues/1

The second issue, press and release being sent simultaneously, was due to the masks being all wrong.

You're masking off only the latest 6 bits, but we actually care about both the oldest (highest) bits and the newest (lowest) bits, with some "don't cares" in the middle, as referenced in the Hackaday article. I've adjusted the masks to suit

However, in the case of PATTERN_DOWN/PATTERN_UP, we do want to be looking at only those last 6 bits, so it changes state as quickly as a press/release event does. Otherwise if you're waiting for all 16 bits, you could be in a situation where a button is pressed, a press event is generated, but isUp/isDown is out of sync until an additional 10 cycles have passed! In this case we need an additional mask, which I've added.

I'm sending a pull request, I've kept the masks as pure binary as then they're much more human readable, there's no risk of them getting out of sync with the comments, and there's no performance penalty to doing so. I've also updated the documentation to match.